### PR TITLE
Added directory creation

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -15,4 +15,14 @@ class burp::server {
   # Set settings in /etc/burp/burp-server.conf
   create_resources( 'burp::defines::burp_server', $burp::burp_server_hash )
 
+  if has_key($burp::burp_server_hash, 'directory') {
+    $directory_hash = $burp::burp_server_hash[directory]
+    if is_hash($directory_hash) {
+      $directory = $directory_hash[value]
+    }
+    file { "$directory":
+      ensure  => present,
+      mode    => '600',
+    }
+  }
 }


### PR DESCRIPTION
burp doesn't create the backup directory so extract it from the hash and create it